### PR TITLE
Expose resetLocalStateForTests to users

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,17 @@
-
 export = ReactSingletonHook;
 export as namespace ReactSingletonHook;
 
 declare namespace ReactSingletonHook {
-  function singletonHook<ValueType>(initialState: ValueType | (() => ValueType), useHook: () => ValueType): () => ValueType;
-  function SingletonHooksContainer(): any;
+  function singletonHook<ValueType>(
+    initialState: ValueType | (() => ValueType),
+    useHook: () => ValueType
+  ): () => ValueType;
+
+  function SingletonHooksContainer(): JSX.Element;
+  /**
+   * Callback that resets the local state for tests.
+   *
+   * Do not use in production!
+   */
+  function resetLocalStateForTests(): void;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-singleton-hook",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Share custom hook state across all components",
   "keywords": [
     "react",

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
 import { singletonHook } from './singletonHook';
-import { SingletonHooksContainer } from './components/SingletonHooksContainer';
+import { SingletonHooksContainer, resetLocalStateForTests } from './components/SingletonHooksContainer';
 
 export {
   singletonHook,
-  SingletonHooksContainer
+  SingletonHooksContainer,
+  resetLocalStateForTests
 };
 
 const ReactSingletonHook = {
   singletonHook,
-  SingletonHooksContainer
+  SingletonHooksContainer,
+  resetLocalStateForTests
 };
 
 export default ReactSingletonHook;


### PR DESCRIPTION
As per the issue I raised, this PR exposes the resetLocalState for tests.

It fixes the bug in my tests where I get a warning:
`"SingletonHooksContainer is mounted second time. You should mount SingletonHooksContainer before any other component and never unmount it.Alternatively, dont use SingletonHooksContainer it at all, we will handle that for you."`

Maybe there is a better way of exposing this functionality, but this solves the issue for me. 
